### PR TITLE
new instructions on manually recreating momix env

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ For running 2. also annotations from MSigDB are required and a download script i
 
 ## Install the software environment
 
+---
+
+### UPDATE: 14/11/2023
+
+Some users have reported issues in recreating the conda environment due to conflict between package version.
+If you encounter problems during installation, please refer to [this bash script](momix_env.sh) that recreates all the dependency tree manually and to [this thread on Issues](https://github.com/cantinilab/momix-notebook/issues/9) for further information.
+
+---
+
 * Install conda from https://docs.conda.io/en/latest/miniconda.html
  * create a new environment: `conda create -n momix -c conda-forge -c bioconda -c lcantini momix r-irkernel`
 

--- a/momix_env.sh
+++ b/momix_env.sh
@@ -1,0 +1,38 @@
+#initialize conda environment
+conda create -n momix -c conda-forge -y  "python>=3.6,<3.7" r-base
+
+# activate env
+conda activate momix
+
+# install jupyter through pip
+pip install jupyter
+
+# install r dependencies (this will take a while) 
+conda install -c conda-forge -y r-survival r-rgcca r-icluster r-gparotation r-ggplot2 r-clustercrit r-devtools r-irkernel
+
+# install missing python dependencies directly from github 
+pip install git+https://github.com/mims-harvard/scikit-fusion
+
+# install omicade4
+conda install -c bioconda -y bioconductor-omicade4
+
+# install mofa
+pip install mofapy
+Rscript -e 'devtools::install_github("bioFAM/MOFA")'
+
+#install fgsea from devtoools
+Rscript -e 'devtools::install_github("ctlab/fgsea")'
+
+# install MSFA
+Rscript -e 'devtools::install_github("lcan88/MSFA")'
+
+#install missing packages frm CRAN:
+Rscript -e 'install.packages(c("r.jive","IntNMF", "InterSIM", "tensorBSS"),  repos="http://cran.us.r-project.org")'
+
+
+#download notebooks
+git clone https://github.com/cantinilab/momix-notebook
+
+# run jupyter
+jupyter notebook
+


### PR DESCRIPTION
Hello,

I added instructions on how to recreate a momix `conda` environment from scratches to help people solve the conflict around package versions.

I tested it on my Linux machine (Ubuntu version 20.04) and I was able to run the notebooks.

Hope this helps!

Best,

Daniele